### PR TITLE
Fix: 修复临时文件累积问题

### DIFF
--- a/nonebot_plugin_course_schedule/commands/group_schedule.py
+++ b/nonebot_plugin_course_schedule/commands/group_schedule.py
@@ -121,5 +121,5 @@ async def _(bot: Bot, event: GroupMessageEvent, arg: Message = CommandArg()):
         return None
 
     next_courses.sort(key=lambda x: (x["start_time"] is None, x["start_time"]))
-    image_path = await image_generator.generate_schedule_image(next_courses)
-    await group_schedule.send(MessageSegment.image(image_path))
+    image_bytes = await image_generator.generate_schedule_image(next_courses)
+    await group_schedule.send(MessageSegment.image(image_bytes))

--- a/nonebot_plugin_course_schedule/commands/show_today.py
+++ b/nonebot_plugin_course_schedule/commands/show_today.py
@@ -106,7 +106,7 @@ async def _(
     for course in filtered_courses:
         course["nickname"] = nickname
 
-    image_path = (
+    image_bytes = (
         await image_generator.generate_user_schedule_image(filtered_courses, nickname)
         if mode == "today"
         else await image_generator.generate_user_schedule_image(
@@ -114,4 +114,4 @@ async def _(
         )
     )
 
-    await show_today.finish(MessageSegment.image(image_path))
+    await show_today.finish(MessageSegment.image(image_bytes))

--- a/nonebot_plugin_course_schedule/commands/weekly_ranking.py
+++ b/nonebot_plugin_course_schedule/commands/weekly_ranking.py
@@ -78,7 +78,7 @@ async def _(bot: Bot, event: GroupMessageEvent):
         return
 
     ranking_data.sort(key=lambda x: x["total_duration"], reverse=True)
-    image_path = await image_generator.generate_ranking_image(
+    image_bytes = await image_generator.generate_ranking_image(
         ranking_data, start_of_week, end_of_week
     )
-    await weekly_ranking.send(MessageSegment.image(image_path))
+    await weekly_ranking.send(MessageSegment.image(image_bytes))

--- a/nonebot_plugin_course_schedule/utils/image_generator.py
+++ b/nonebot_plugin_course_schedule/utils/image_generator.py
@@ -3,7 +3,6 @@
 本模块负责生成插件所需的各种图片，如图形化课程表和排行榜。
 """
 import asyncio
-import tempfile
 from datetime import datetime, timezone, timedelta, date
 from io import BytesIO
 from typing import Dict, List
@@ -121,8 +120,8 @@ class ImageGenerator:
 
         return lines
     
-    async def generate_schedule_image(self, courses: List[Dict]) -> str:
-        """生成课程表图片并返回临时文件路径"""
+    async def generate_schedule_image(self, courses: List[Dict]) -> bytes:
+        """生成课程表图片并返回字节数据"""
         height = c.GS_PADDING * 2 + 120 + len(courses) * c.GS_ROW_HEIGHT
         image = Image.new("RGB", (c.GS_WIDTH, height), c.GS_BG_COLOR)
         draw = ImageDraw.Draw(image)
@@ -260,17 +259,15 @@ class ImageGenerator:
 
             y_offset += c.GS_ROW_HEIGHT
 
-        temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".png")
-        temp_path = temp_file.name
-        image.save(temp_path, format="PNG")
-        temp_file.close()
-
-        return temp_path
+        # 转换为字节数据
+        img_stream = BytesIO()
+        image.save(img_stream, format="PNG")
+        return img_stream.getvalue()
 
     async def generate_user_schedule_image(
         self, courses: List[Dict], nickname: str, date: datetime = None 
-    ) -> str:
-        """为单个用户生成今日课程表图片"""
+    ) -> bytes:
+        """为单个用户生成今日课程表图片并返回字节数据"""
         day: str = date.strftime("%m-%d ") if date else "今日"
         weekday: int = date.weekday() if date else datetime.now(timezone(timedelta(hours=8))).weekday()
         weeklist = ["周一", "周二", "周三", "周四", "周五", "周六", "周日"]
@@ -378,17 +375,15 @@ class ImageGenerator:
             fill=c.US_SUBTITLE_COLOR,
         )
 
-        temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".png")
-        temp_path = temp_file.name
-        image.save(temp_path, format="PNG")
-        temp_file.close()
-
-        return temp_path
+        # 转换为字节数据
+        img_stream = BytesIO()
+        image.save(img_stream, format="PNG")
+        return img_stream.getvalue()
 
     async def generate_ranking_image(
         self, ranking_data: List[Dict], start_date: date, end_date: date
-    ) -> str:
-        """生成排行榜图片"""
+    ) -> bytes:
+        """生成排行榜图片并返回字节数据"""
         height = (
             c.RANKING_HEADER_HEIGHT
             + len(ranking_data) * c.RANKING_ROW_HEIGHT
@@ -514,11 +509,10 @@ class ImageGenerator:
 
             y_offset += c.RANKING_ROW_HEIGHT
 
-        temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".png")
-        temp_path = temp_file.name
-        image.save(temp_path, format="PNG")
-        temp_file.close()
-        return temp_path
+        # 转换为字节数据
+        img_stream = BytesIO()
+        image.save(img_stream, format="PNG")
+        return img_stream.getvalue()
 
 
 image_generator = ImageGenerator()


### PR DESCRIPTION
当前每响应一次课表生成，会将生成的图片保存到系统的临时目录（`tempfile`）中，但由于使用了 `tempfile.NamedTemporaryFile(delete=False, suffix=".png")` 创建临时文件，且插件未见清理相关代码，导致随着使用次数增加，临时文件在tmp文件夹中不断累积，占用磁盘空间。

<img width="596" height="170" alt="QQ_1766748200556" src="https://github.com/user-attachments/assets/adcc805d-d84e-4763-9e3d-495485c6b8bc" />

我对比了生成后立即清理、定时清理以及直接返回字节后，认为**直接发送图像字节数据**是最简便、改动最小的解决方案。该方案在图片生成后，直接返回字节数据而非文件路径，实现真正的"无缓存"处理。

此方案不会减慢生成速度（考虑到内存速度远高于外存，甚至可能会略微加快），且由于是字节流直出，不会影响图片的生成效果和质量。